### PR TITLE
perf: Cache JSON Schema validators by their schema's JSON representation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [check, test, test-slow]
-    if: github.repository == 'Zac-HD/hypothesis-jsonschema' &&  github.ref == 'refs/heads/master'
+    if: github.repository == 'python-jsonschema/hypothesis-jsonschema' &&  github.ref == 'refs/heads/master'
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+#### 0.22.1 - 2023-02-07
 - Cache JSON Schema validators by their schema's JSON representation
 
 #### 0.22.0 - 2021-12-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Cache JSON Schema validators by their schema's JSON representation
+
 #### 0.22.0 - 2021-12-15
 - never generate trailing newlines for regex patterns ending in `$`
   (allowed by Python, but not by JSON Schema)

--- a/deps/check.in
+++ b/deps/check.in
@@ -10,7 +10,6 @@ flake8-docstrings
 flake8-mutable
 # flake8-noqa  # See https://github.com/JBKahn/flake8-print/issues/50
 flake8-print
-flake8-simplify
 flake8-strftime
 mypy
 pep8-naming

--- a/deps/check.txt
+++ b/deps/check.txt
@@ -4,8 +4,6 @@
 #
 #    pip-compile --output-file=deps/check.txt deps/check.in
 #
-astor==0.8.1
-    # via flake8-simplify
 attrs==21.2.0
     # via flake8-bugbear
 autoflake==1.4
@@ -36,7 +34,6 @@ flake8==4.0.1
     #   flake8-mutable
     #   flake8-polyfill
     #   flake8-print
-    #   flake8-simplify
     #   flake8-strftime
     #   pep8-naming
 flake8-2020==1.6.1
@@ -63,8 +60,6 @@ flake8-polyfill==1.0.2
     #   pep8-naming
 flake8-print==4.0.0
     # via -r deps/check.in
-flake8-simplify==0.14.2
-    # via -r deps/check.in
 flake8-strftime==0.3.2
     # via -r deps/check.in
 gitdb==4.0.9
@@ -77,7 +72,6 @@ importlib-metadata==4.2.0
     #   flake8
     #   flake8-2020
     #   flake8-comprehensions
-    #   flake8-simplify
     #   stevedore
 isort==5.10.1
     # via shed

--- a/src/hypothesis_jsonschema/__init__.py
+++ b/src/hypothesis_jsonschema/__init__.py
@@ -3,7 +3,7 @@
 The only public API is `from_schema`; check the docstring for details.
 """
 
-__version__ = "0.22.0"
+__version__ = "0.22.1"
 __all__ = ["from_schema"]
 
 from ._from_schema import from_schema

--- a/src/hypothesis_jsonschema/_canonicalise.py
+++ b/src/hypothesis_jsonschema/_canonicalise.py
@@ -71,25 +71,27 @@ def next_down(val: float) -> float:
     return out
 
 
-@dataclass(eq=False, slots=True)
 class CacheableSchema:
     """Cache schema by its JSON representation.
 
     Canonicalisation is not required as schemas with the same JSON representation
     will have the same validator.
     """
-    schema: Schema
-    hash_value: int
+    __slots__ = ("schema", "encoded")
+
+    def __init__(self, schema: Schema) -> None:
+        self.schema = schema
+        self.encoded = hash(json.dumps(schema, sort_keys=True))
 
     def __eq__(self, other: "CacheableSchema") -> bool:
-        return self.hash_value == other.hash_value
+        return self.encoded == other.encoded
 
     def __hash__(self) -> int:
-        return self.hash_value
+        return self.encoded
 
 
 def _get_validator_class(schema: Schema) -> JSONSchemaValidator:
-    return __get_validator_class(CacheableSchema(schema, hash(json.dumps(schema))))
+    return __get_validator_class(CacheableSchema(schema))
 
 
 @lru_cache(maxsize=128)

--- a/src/hypothesis_jsonschema/_canonicalise.py
+++ b/src/hypothesis_jsonschema/_canonicalise.py
@@ -83,9 +83,7 @@ class CacheableSchema:
         self.schema = schema
         self.encoded = hash(json.dumps(schema, sort_keys=True))
 
-    def __eq__(self, other: object) -> bool:
-        if not isinstance(other, CacheableSchema):
-            return NotImplemented
+    def __eq__(self, other: "CacheableSchema") -> bool:  # type: ignore
         return self.encoded == other.encoded
 
     def __hash__(self) -> int:

--- a/src/hypothesis_jsonschema/_canonicalise.py
+++ b/src/hypothesis_jsonschema/_canonicalise.py
@@ -76,6 +76,7 @@ class CacheableSchema:
     Canonicalisation is not required as schemas with the same JSON representation
     will have the same validator.
     """
+
     __slots__ = ("schema", "encoded")
 
     def __init__(self, schema: Schema) -> None:

--- a/src/hypothesis_jsonschema/_canonicalise.py
+++ b/src/hypothesis_jsonschema/_canonicalise.py
@@ -82,7 +82,9 @@ class CacheableSchema:
         self.schema = schema
         self.encoded = hash(json.dumps(schema, sort_keys=True))
 
-    def __eq__(self, other: "CacheableSchema") -> bool:
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, CacheableSchema):
+            return NotImplemented
         return self.encoded == other.encoded
 
     def __hash__(self) -> int:

--- a/src/hypothesis_jsonschema/_canonicalise.py
+++ b/src/hypothesis_jsonschema/_canonicalise.py
@@ -17,7 +17,6 @@ import itertools
 import json
 import math
 import re
-from dataclasses import dataclass
 from fractions import Fraction
 from functools import lru_cache
 from typing import Any, Dict, List, Optional, Tuple, Union


### PR DESCRIPTION
This PR adds hashing for JSON Schema validators - it allows us to avoid repeatedly re-checking the same schemas with metaschemas.

It turned out that it is a significant performance improvement for Schemathesis (around ~25%) and for the `hypothesis-jsonschema` test suite too.

This approach to caching is based on the fact that it is faster to run `json.dumps` than `validator.check_schema` and JSON Schema validators are the same for semantically equivalent schemas even without canonicalization.

P.S. The wrapper is similar to what I removed earlier in aac3ba02223f8cd91f77b4e9bf352176fb43b083 but is applied to the place where it actually works.